### PR TITLE
docs: agregar .env.example con las variables de entorno requeridas

### DIFF
--- a/api/.env.example
+++ b/api/.env.example
@@ -1,0 +1,17 @@
+# ─────────────────────────────
+# Entorno de ejecución
+# ─────────────────────────────
+NODE_ENV=development
+
+# ─────────────────────────────
+# URL de la base de datos
+# Formato: postgresql://USER:PASSWORD@HOST:PORT/DATABASE
+# Cambia según el entorno (dev/staging/prod)
+DATABASE_URL=postgresql://<user>:<password>@<host>:<port>/<database_name>
+
+# ─────────────────────────────
+# Cloudinary (servicio de almacenamiento de imágenes)
+# ─────────────────────────────
+CLOUDINARY_CLOUD_NAME=<your_cloudinary_cloud_name>
+CLOUDINARY_API_KEY=<your_cloudinary_api_key>
+CLOUDINARY_API_SECRET=<your_cloudinary_api_secret>


### PR DESCRIPTION
Se añadió el archivo .env.example que contiene todas las variables de entorno necesarias para ejecutar el proyecto localmente. Esto ayuda a mantener consistencia entre entornos (development, staging, production) sin exponer valores sensibles.

Checklist:

 Archivo .env.example agregado

 Contiene estructura y comentarios explicativos

 No contiene credenciales reales

Notas:

Se espera que cada miembro del equipo copie este archivo y lo renombre según el entorno correspondiente (.env.development, .env.staging, etc.)