### PR TITLE
feat: Configuración dinámica de CORS según entorno

### DIFF
--- a/api/.env.example
+++ b/api/.env.example
@@ -20,3 +20,9 @@ CLOUDINARY_API_SECRET=<your_cloudinary_api_secret>
 # JWT key
 # ─────────────────────────────
 JWT_SECRET=secreto
+PORT=3001
+
+# ─────────────────────────────
+# Frontend Url
+# ─────────────────────────────
+CORS_ORIGINS=http://localhost:3000,https://repo-prueba-zeta.vercel.app

--- a/api/src/main.ts
+++ b/api/src/main.ts
@@ -8,9 +8,10 @@ async function bootstrap() {
   const app = await NestFactory.create(AppModule);
   const configService = app.get(ConfigService);
 
+  const corsOrigins = configService.get<string>('CORS_ORIGINS')?.split(',') || [];
 
   app.enableCors({
-    origin: ['http://localhost:3000', 'https://repo-prueba-zeta.vercel.app'],
+    origin: corsOrigins,
     credentials: true,
   });
 


### PR DESCRIPTION
Se actualizó el archivo main.ts para que los orígenes permitidos por CORS se obtengan desde la variable de entorno CORS_ORIGINS, permitiendo una configuración más flexible y mantenible entre entornos (local, staging y producción).

Además, se ajustó el .env.staging agregando la variable:
- CORS_ORIGINS=http://localhost:3000,https://repo-prueba-zeta.vercel.app

Con esto, el frontend puede conectarse correctamente desde diferentes entornos sin necesidad de modificar el código fuente.