### PR TITLE
Ajustes en la tasa de cambio Stripe

### DIFF
--- a/api/src/prisma/migrations/20250702050328_add_tasa_cambio_ars/migration.sql
+++ b/api/src/prisma/migrations/20250702050328_add_tasa_cambio_ars/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "Donacion" ADD COLUMN     "montoARS" DOUBLE PRECISION,
+ADD COLUMN     "tasaCambio" DOUBLE PRECISION;

--- a/api/src/prisma/schema.prisma
+++ b/api/src/prisma/schema.prisma
@@ -156,6 +156,9 @@ model Donacion {
   organizacionId String
 
   monto          Float
+  montoARS       Float?
+  tasaCambio     Float?
+
   comprobante    String?    @unique  
   fecha          DateTime     @default(now())
 

--- a/api/src/stripe/stripe.controller.ts
+++ b/api/src/stripe/stripe.controller.ts
@@ -1,7 +1,6 @@
 import {
     Controller,
     Get,
-    Param,
     Post,
     Req,
     Res,
@@ -16,7 +15,6 @@ import { PrismaService } from 'src/prisma/prisma.service';
 import { Request, Response } from 'express';
 import { stripe } from './stripe.service';
 import Stripe from 'stripe';
-import { Public } from '@prisma/client/runtime/library';
 
 @Controller('stripe')
 export class StripeController {
@@ -133,6 +131,8 @@ export class StripeController {
                 organizacionId,
                 mascotaId,
                 monto: amount,
+                montoARS: parseFloat(session.metadata?.montoARS ?? '0'),
+                tasaCambio: parseFloat(session.metadata?.tasaCambio ?? '0'),
                 comprobante: session.id, 
                 estadoPago: session.payment_status ?? 'desconocido',
                 stripeSessionId: session.id,

--- a/api/src/usuarios/usuarios.service.ts
+++ b/api/src/usuarios/usuarios.service.ts
@@ -158,24 +158,33 @@ export class UsuariosService {
 async obtenerDonacionesDelUsuarioAutenticado( usuarioId: string){
   return await this.prisma.donacion.findMany({
     where: { usuarioId },
-    include: {
+    select: {
+      id: true,
+      monto: true,
+      montoARS: true,
+      tasaCambio: true,
+      fecha: true,
+      estadoPago: true,
+      stripeSessionId: true,
+      referenciaPago: true,
       organizacion: {
         select: { nombre: true},
       },
       mascota: {
-        select: { 
+        select: {
           nombre: true,
           imagenes: {
             select: { url: true},
           },
           casos: {
-            select: { descripcion: true,}
+            select: { descripcion: true},
           },
         },
       },
     },
   });
 }
+
 
 async obtenerSolicitudesDelUsuario(usuarioId: string){
   return await this.prisma.solicitudDeAdopcion.findMany({


### PR DESCRIPTION
1. Stripe solo maneja pago en USD, por esa razón se implementa lógica para conversión y uso de la tasa actual de la moneda ARS.
2. Se ajusta el método que entrega las donaciones de cada usuario para enviar también los nuevos datos del cambio de moneda.