### PR TITLE
Cambio en controlador Stripe

### DIFF
--- a/api/src/casos/casos.service.ts
+++ b/api/src/casos/casos.service.ts
@@ -37,8 +37,7 @@ export class CasosService {
         mascota: {
           include: {
             imagenes: {
-              take: 1,
-              orderBy: { subida_en: 'desc'}, // Trae la imagen más reciente
+              orderBy: { subida_en: 'desc'}, 
             },
           },
         },
@@ -55,8 +54,7 @@ export class CasosService {
         mascota: {
           include: {
             imagenes: {
-              take: 1,
-              orderBy: { subida_en: 'desc'}, // Trae solo la imagen más reciente
+              orderBy: { subida_en: 'desc'}, 
             },
           },
         },


### PR DESCRIPTION
1. Se cambia el monto que se guarda en la base de datos.
2. Se ajustan las rutas que traen las imágenes de las macotas para que vengan todas.